### PR TITLE
Add conda environment and ci.yml for GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: ci
+on:
+  push:
+    branches:
+      - master
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.10
+      - run: pip install mkdocs-material
+      - run: pip install mkdocs-git-revision-date-plugin
+      - run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@ This documentation project makes use of
   * [MkDocs](https://www.mkdocs.org/)
   * [MkDocs Material Design Theme](https://squidfunk.github.io/mkdocs-material)
 
+To make changes and test it locally, you have to setup mkdocs-material and all other dependencies. We are delivering a conda environemnt file right within this repo. A possible installation scenario for macOS using Homebrew might look like:
+
+```
+# Install miniconda using Homebrew
+brew install --cask miniconda
+ 
+# Setup conda
+conda init "$(basename "${SHELL}")"
+# --> For changes to take effect, close and re-open your current shell <--
+
+# Fetch the documentation repository
+git clone https://github.com/hpc-unibe-ch/hpc-docs.git
+cd hpc-docs
+
+# Create and activate the environment
+conda create
+conda activate hpcdocs
+
+# Start the local mkdocs webserver that renders and displays all change instantly
+mkdocs serve
+```
+
 ## Contributions
 
 Everybody is invited to contribute to the doucmentation. If you find that certain topics
@@ -15,12 +37,13 @@ are not sufficiently covered or difficult to understand, you can fork this repos
 fix the respective part and then send us a pull request. Even for such small things like
 typos! Yes, really, we appreciate your effort!
 
-You can make our live easier when you ship logically selfcontained pull requests, which means:
+You can make our life easier when you ship logically selfcontained pull requests, which means:
 
   * one logical change per pull reuqest (typos or a new paragraph on topic X, another for topic Y)
   * squash multiple commits before starting the pull request
 
 Thanks you!
+
 
 ## License
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,7 @@
+name: hpcdocs
+dependencies:
+  - python=3.10
+  - pip
+  - pip:
+      - mkdocs-material
+      - mkdocs-git-revision-date-plugin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,20 +62,14 @@ nav:
   - FAQ: general/faq.md
   - Hall of Fame: halloffame.md
   - Code of Conduct: code-of-conduct.md
-      #
-      #
-      #  - Home: index.md
-      #  - User Guide:
-      #    - Getting Started: user-guide/getting-started.md
-      #    - File Transfer: user-guide/file-transfer.md
-      #    - Job Management with Slurm:
+
 
 # Copyright footer
 copyright: 'Copyright &copy; University of Bern, IT Service Office'
-# Social links at botoom right
+# Link to repo
 repo_name: 'hpc-unibe-ch/hpc-docs'
 repo_url: 'https://github.com/hpc-unibe-ch/hpc-docs'
-edit_uri: ''
+edit_uri: 'edit/main/docs'
 
 # Configuration
 theme:
@@ -84,24 +78,31 @@ theme:
 extra_css:
  - 'stylesheets/unibe.css'
 
+plugins:
+  - git-revision-date
+
 # See https://python-markdown.github.io/extensions/ and
 # See https://github.com/Python-Markdown/markdown/wiki/Third-Party-Extensions#Bundles
 #     https://facelessuser.github.io/pymdown-extensions/
 markdown_extensions:
   - abbr
+  - admonition
+  - attr_list
   - def_list
   - footnotes
-  - tables
-  - admonition
   - codehilite:
       guess_lang: false
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - sane_lists
   - smarty
+  - tables
   - toc
-  - pymdownx.superfences
-  - attr_list
 
-
+# Social links bottom right
 extra:
   social:
     - icon: fontawesome/brands/github-alt


### PR DESCRIPTION
This commit introduces several automation things:
- Installation instructions for the automated conda env installation
- The environment.yml defining the conda environment hpcdocs, fixes #29
- The ci.yml for a GitHub aciton that automatically renders the
  documentation on any merge/push to master, fixes #28

# Closes issue(s)

See above.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [X] I have tested this code
- [X] I have updated the README.md (if available and necessary)
