### PR TITLE
Readd missinng search plugins

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: HPC Documentation
-#theme: mkdocs
+
 use_directory_urls: false
 nav:
   - News: general/news.md
@@ -80,6 +80,7 @@ extra_css:
 
 plugins:
   - git-revision-date
+  - search
 
 # See https://python-markdown.github.io/extensions/ and
 # See https://github.com/Python-Markdown/markdown/wiki/Third-Party-Extensions#Bundles


### PR DESCRIPTION
When git-revision-date plugin was added, the search plugin was
automatically removed. When listing plugins in mkdocs.yml, all plugins
must be added even those that are on by default. Forgetting to do so,
disabled the plugins in question.

# Closes issue(s)

Fixes #35

# Changes include
- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist
- [X] I have updated the README.md (if available and necessary)
- [X] I have tested this code
